### PR TITLE
Delete messages "also sent to the channel"

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+	"tabWidth": 2,
+	"semi": false,
+	"singleQuote": true
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,0 @@
-{
-	"tabWidth": 2,
-	"semi": false,
-	"singleQuote": true
-}

--- a/index.js
+++ b/index.js
@@ -5,16 +5,16 @@ const axios = require('axios')
 
 const app = new App({
   signingSecret: process.env.SIGNING_SECRET,
-  token: process.env.BOT_TOKEN,
+  token: process.env.BOT_TOKEN
 })
 
 const shipsTable = new AirtablePlus({
   apiKey: process.env.AIRTABLE_API_KEY,
   baseID: 'appnzwlmqTft69NhW',
-  tableName: 'Ships',
+  tableName: 'Ships'
 })
 
-app.event('message', async (body) => {
+app.event('message', async body => {
   if (
     (body.event.channel === 'CQPG0EUD8' ||
       body.event.channel === 'C0M8PUPU6') &&
@@ -33,7 +33,7 @@ app.event('message', async (body) => {
         token: process.env.OAUTH_TOKEN,
         channel: body.event.channel,
         ts: body.event.event_ts,
-        broadcast_delete: true, //if it's a threaded message, leave it in the thread
+        broadcast_delete: true //if it's a threaded message, leave it in the thread
       })
       if (!body.event.hasOwnProperty('thread_ts')) {
         //check if it's a threaded message
@@ -42,7 +42,7 @@ app.event('message', async (body) => {
           attachments: [],
           channel: body.event.channel,
           text: `Ahoy Matey! You posted a message without a file or URL:\n\n"${body.event.text}"\n\nI’ve removed your message, but you can repost a shipped project with a file or URL and I’ll let it be. Let <@U4QAK9SRW> know if you have any questions or if I made a mistake.`,
-          user: body.event.user,
+          user: body.event.user
         })
       } else {
         await app.client.chat.postEphemeral({
@@ -50,7 +50,7 @@ app.event('message', async (body) => {
           attachments: [],
           channel: body.event.channel,
           user: body.event.user,
-          text: `Ahoy matey! You posted a message in a thread and sent it to the channel - I've removed your message from the channel (as it's reserved for ships), but left it in the thread. Let <@U4QAK9SRW> know if you have any questions or if I made a mistake.`,
+          text: `Ahoy matey! You posted a message in a thread and sent it to the channel - I've removed your message from the channel (as it's reserved for ships), but left it in the thread. Let <@U4QAK9SRW> know if you have any questions or if I made a mistake.`
         })
       }
     } else {
@@ -58,20 +58,20 @@ app.event('message', async (body) => {
         let fileId = body.message.files[0].id
         let publicUrl = await app.client.files.sharedPublicURL({
           token: process.env.USER_TOKEN,
-          file: fileId,
+          file: fileId
         })
         console.log(publicUrl.file.permalink_public)
 
         let acceptedFileTypes = ['jpg', 'jpeg', 'png', 'gif']
-        let containsAcceptedFileTypes = acceptedFileTypes.some((el) =>
+        let containsAcceptedFileTypes = acceptedFileTypes.some(el =>
           body.message.files[0].name.includes(el)
         )
 
         if (containsAcceptedFileTypes) {
           axios
             .get(publicUrl.file.permalink_public)
-            .then((res) => cheerio.load(res.data))
-            .then(($) => {
+            .then(res => cheerio.load(res.data))
+            .then($ => {
               let imgUrl = $('img').attr('src')
               console.log(imgUrl)
               logShip(
@@ -104,14 +104,14 @@ app.event('message', async (body) => {
 const logShip = async (ts, userId, message, imageUrl, projectUrl) => {
   let userInfo = await app.client.users.info({
     token: process.env.BOT_TOKEN,
-    user: userId,
+    user: userId
   })
   let username = `@${userInfo.user.name}`
   let avatar = userInfo.user.profile.image_192
 
   let profile = await app.client.users.profile.get({
     token: process.env.BOT_TOKEN,
-    user: userId,
+    user: userId
   })
 
   let website
@@ -130,16 +130,16 @@ const logShip = async (ts, userId, message, imageUrl, projectUrl) => {
     'User Website': website,
     'Image URL': imageUrl,
     'Project URL': projectUrl,
-    Public: true,
+    Public: true
   })
 }
 
-const hasUrl = (message) =>
+const hasUrl = message =>
   new RegExp(
     '([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?(/.*)?'
   ).test(message)
 
-const findUrl = (message) => {
+const findUrl = message => {
   let url = message.match(/<.*>/)[0]
   return url.slice(1, url.indexOf('|'))
 }

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ app.event('message', async (body) => {
           token: process.env.BOT_TOKEN,
           attachments: [],
           channel: body.event.channel,
+          user: body.event.user,
           text: `Ahoy matey! You posted a message in a thread and sent it to the channel - I've removed your message from the channel (as it's reserved for ships), but left it in the thread. Let <@U4QAK9SRW> know if you have any questions or if I made a mistake.`,
         })
       }

--- a/index.js
+++ b/index.js
@@ -1,65 +1,100 @@
-const { App } = require('@slack/bolt')
-const AirtablePlus = require('airtable-plus')
-const cheerio = require('cheerio')
-const axios = require('axios')
+const { App } = require("@slack/bolt");
+const AirtablePlus = require("airtable-plus");
+const cheerio = require("cheerio");
+const axios = require("axios");
 
 const app = new App({
   signingSecret: process.env.SIGNING_SECRET,
-  token: process.env.BOT_TOKEN
+  token: process.env.BOT_TOKEN,
 });
 
 const shipsTable = new AirtablePlus({
   apiKey: process.env.AIRTABLE_API_KEY,
-  baseID: 'appnzwlmqTft69NhW',
-  tableName: 'Ships'
-})
+  baseID: "appnzwlmqTft69NhW",
+  tableName: "Ships",
+});
 
-app.event('message', async body => {
-  if ((body.event.channel === 'CQPG0EUD8' || body.event.channel === 'C0M8PUPU6') && typeof body.message.thread_ts === 'undefined') {
-    if (!hasUrl(body.event.text)
-      && body.event.subtype !== 'message_deleted' && body.event.files === undefined
-      && body.message.text !== `<@${body.message.user}> has joined the channel`) {
+app.event("message", async (body) => {
+  if (
+    (body.event.channel === "CQPG0EUD8" ||
+      body.event.channel === "C0M8PUPU6") &&
+    (typeof body.message.thread_ts === "undefined" ||
+      body.event.subtype === "thread_broadcast")
+  ) {
+    if (
+      (!hasUrl(body.event.text) &&
+        body.event.subtype !== "message_deleted" &&
+        body.event.files === undefined &&
+        body.message.text !==
+          `<@${body.message.user}> has joined the channel`) ||
+      body.event.subtype == "thread_broadcast"
+    ) {
       await app.client.chat.delete({
         token: process.env.OAUTH_TOKEN,
         channel: body.event.channel,
-        ts: body.event.event_ts
-      })
-      await app.client.chat.postEphemeral({
-        token: process.env.BOT_TOKEN,
-        attachments: [],
-        channel: body.event.channel,
-        text: `Ahoy Matey! You posted a message without a file or URL:\n\n"${body.event.text}"\n\nI’ve removed your message, but you can repost a shipped project with a file or URL and I’ll let it be. Let <@U4QAK9SRW> know if you have any questions or if I made a mistake.`,
-        user: body.event.user
-      })
+        ts: body.event.event_ts,
+        broadcast_delete: true, //if it's a threaded message, leave it in the thread
+      });
+      if (!body.event.hasOwnProperty("thread_ts")) {
+        //check if it's a threaded message
+        await app.client.chat.postEphemeral({
+          token: process.env.BOT_TOKEN,
+          attachments: [],
+          channel: body.event.channel,
+          text: `Ahoy Matey! You posted a message without a file or URL:\n\n"${body.event.text}"\n\nI’ve removed your message, but you can repost a shipped project with a file or URL and I’ll let it be. Let <@U4QAK9SRW> know if you have any questions or if I made a mistake.`,
+          user: body.event.user,
+        });
+      } else {
+        await app.client.chat.postEphemeral({
+          token: process.env.BOT_TOKEN,
+          attachments: [],
+          channel: body.event.channel,
+          text: `Ahoy matey! You posted a message in a thread and sent it to the channel - I've removed your message from the channel (as it's reserved for ships), but left it in the thread. Let <@U4QAK9SRW> know if you have any questions or if I made a mistake.`,
+        });
+      }
     } else {
       if (body.message.files) {
-        let fileId = body.message.files[0].id
+        let fileId = body.message.files[0].id;
         let publicUrl = await app.client.files.sharedPublicURL({
           token: process.env.USER_TOKEN,
-          file: fileId
-        })
-        console.log(publicUrl.file.permalink_public)
+          file: fileId,
+        });
+        console.log(publicUrl.file.permalink_public);
 
-        let acceptedFileTypes = ['jpg', 'jpeg', 'png', 'gif']
-        let containsAcceptedFileTypes = acceptedFileTypes.some(el => body.message.files[0].name.includes(el))
+        let acceptedFileTypes = ["jpg", "jpeg", "png", "gif"];
+        let containsAcceptedFileTypes = acceptedFileTypes.some((el) =>
+          body.message.files[0].name.includes(el)
+        );
 
         if (containsAcceptedFileTypes) {
-          axios.get(publicUrl.file.permalink_public)
-            .then(res => cheerio.load(res.data))
-            .then($ => {
-              let imgUrl = $('img').attr('src')
-              console.log(imgUrl)
-              logShip(body.message.ts, body.message.user, body.message.text, imgUrl)
-            })
+          axios
+            .get(publicUrl.file.permalink_public)
+            .then((res) => cheerio.load(res.data))
+            .then(($) => {
+              let imgUrl = $("img").attr("src");
+              console.log(imgUrl);
+              logShip(
+                body.message.ts,
+                body.message.user,
+                body.message.text,
+                imgUrl
+              );
+            });
         } else {
-          logShip(body.message.ts, body.message.user, body.message.text, null, publicUrl.file.permalink_public)
+          logShip(
+            body.message.ts,
+            body.message.user,
+            body.message.text,
+            null,
+            publicUrl.file.permalink_public
+          );
         }
       } else {
-        let url = findUrl(body.message.text)
-        console.log(url)
-        let message = body.message.text.replace(/<.*>/, '')
-        console.log(message)
-        logShip(body.message.ts, body.message.user, message, null, url)
+        let url = findUrl(body.message.text);
+        console.log(url);
+        let message = body.message.text.replace(/<.*>/, "");
+        console.log(message);
+        logShip(body.message.ts, body.message.user, message, null, url);
       }
     }
   }
@@ -68,45 +103,44 @@ app.event('message', async body => {
 const logShip = async (ts, userId, message, imageUrl, projectUrl) => {
   let userInfo = await app.client.users.info({
     token: process.env.BOT_TOKEN,
-    user: userId
-  })
-  let username = `@${userInfo.user.name}`
-  let avatar = userInfo.user.profile.image_192
+    user: userId,
+  });
+  let username = `@${userInfo.user.name}`;
+  let avatar = userInfo.user.profile.image_192;
 
   let profile = await app.client.users.profile.get({
     token: process.env.BOT_TOKEN,
-    user: userId
-  })
+    user: userId,
+  });
 
-  let website
+  let website;
   try {
-    website = profile.profile.fields['Xf5LNGS86L'].value
-  } catch { }
+    website = profile.profile.fields["Xf5LNGS86L"].value;
+  } catch {}
 
-  let d = new Date(ts * 1000)
+  let d = new Date(ts * 1000);
 
   shipsTable.create({
-    'Timestamp': d.toISOString(),
-    'Message': message,
-    'User ID': userId,
-    'User Name': username,
-    'User Avatar': avatar,
-    'User Website': website,
-    'Image URL': imageUrl,
-    'Project URL': projectUrl,
-    'Public': true
-  })
-}
+    Timestamp: d.toISOString(),
+    Message: message,
+    "User ID": userId,
+    "User Name": username,
+    "User Avatar": avatar,
+    "User Website": website,
+    "Image URL": imageUrl,
+    "Project URL": projectUrl,
+    Public: true,
+  });
+};
 
-const hasUrl = message => (
+const hasUrl = (message) =>
   new RegExp(
-    '([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?(/.*)?'
-  ).test(message)
-);
+    "([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?(/.*)?"
+  ).test(message);
 
-const findUrl = message => {
-  let url = message.match(/<.*>/)[0]
-  return url.slice(1, url.indexOf('|'))
+const findUrl = (message) => {
+  let url = message.match(/<.*>/)[0];
+  return url.slice(1, url.indexOf("|"));
 };
 
 (async () => {

--- a/index.js
+++ b/index.js
@@ -1,41 +1,41 @@
-const { App } = require("@slack/bolt");
-const AirtablePlus = require("airtable-plus");
-const cheerio = require("cheerio");
-const axios = require("axios");
+const { App } = require('@slack/bolt')
+const AirtablePlus = require('airtable-plus')
+const cheerio = require('cheerio')
+const axios = require('axios')
 
 const app = new App({
   signingSecret: process.env.SIGNING_SECRET,
   token: process.env.BOT_TOKEN,
-});
+})
 
 const shipsTable = new AirtablePlus({
   apiKey: process.env.AIRTABLE_API_KEY,
-  baseID: "appnzwlmqTft69NhW",
-  tableName: "Ships",
-});
+  baseID: 'appnzwlmqTft69NhW',
+  tableName: 'Ships',
+})
 
-app.event("message", async (body) => {
+app.event('message', async (body) => {
   if (
-    (body.event.channel === "CQPG0EUD8" ||
-      body.event.channel === "C0M8PUPU6") &&
-    (typeof body.message.thread_ts === "undefined" ||
-      body.event.subtype === "thread_broadcast")
+    (body.event.channel === 'CQPG0EUD8' ||
+      body.event.channel === 'C0M8PUPU6') &&
+    (typeof body.message.thread_ts === 'undefined' ||
+      body.event.subtype === 'thread_broadcast')
   ) {
     if (
       (!hasUrl(body.event.text) &&
-        body.event.subtype !== "message_deleted" &&
+        body.event.subtype !== 'message_deleted' &&
         body.event.files === undefined &&
         body.message.text !==
           `<@${body.message.user}> has joined the channel`) ||
-      body.event.subtype == "thread_broadcast"
+      body.event.subtype == 'thread_broadcast'
     ) {
       await app.client.chat.delete({
         token: process.env.OAUTH_TOKEN,
         channel: body.event.channel,
         ts: body.event.event_ts,
         broadcast_delete: true, //if it's a threaded message, leave it in the thread
-      });
-      if (!body.event.hasOwnProperty("thread_ts")) {
+      })
+      if (!body.event.hasOwnProperty('thread_ts')) {
         //check if it's a threaded message
         await app.client.chat.postEphemeral({
           token: process.env.BOT_TOKEN,
@@ -43,43 +43,43 @@ app.event("message", async (body) => {
           channel: body.event.channel,
           text: `Ahoy Matey! You posted a message without a file or URL:\n\n"${body.event.text}"\n\nI’ve removed your message, but you can repost a shipped project with a file or URL and I’ll let it be. Let <@U4QAK9SRW> know if you have any questions or if I made a mistake.`,
           user: body.event.user,
-        });
+        })
       } else {
         await app.client.chat.postEphemeral({
           token: process.env.BOT_TOKEN,
           attachments: [],
           channel: body.event.channel,
           text: `Ahoy matey! You posted a message in a thread and sent it to the channel - I've removed your message from the channel (as it's reserved for ships), but left it in the thread. Let <@U4QAK9SRW> know if you have any questions or if I made a mistake.`,
-        });
+        })
       }
     } else {
       if (body.message.files) {
-        let fileId = body.message.files[0].id;
+        let fileId = body.message.files[0].id
         let publicUrl = await app.client.files.sharedPublicURL({
           token: process.env.USER_TOKEN,
           file: fileId,
-        });
-        console.log(publicUrl.file.permalink_public);
+        })
+        console.log(publicUrl.file.permalink_public)
 
-        let acceptedFileTypes = ["jpg", "jpeg", "png", "gif"];
+        let acceptedFileTypes = ['jpg', 'jpeg', 'png', 'gif']
         let containsAcceptedFileTypes = acceptedFileTypes.some((el) =>
           body.message.files[0].name.includes(el)
-        );
+        )
 
         if (containsAcceptedFileTypes) {
           axios
             .get(publicUrl.file.permalink_public)
             .then((res) => cheerio.load(res.data))
             .then(($) => {
-              let imgUrl = $("img").attr("src");
-              console.log(imgUrl);
+              let imgUrl = $('img').attr('src')
+              console.log(imgUrl)
               logShip(
                 body.message.ts,
                 body.message.user,
                 body.message.text,
                 imgUrl
-              );
-            });
+              )
+            })
         } else {
           logShip(
             body.message.ts,
@@ -87,63 +87,63 @@ app.event("message", async (body) => {
             body.message.text,
             null,
             publicUrl.file.permalink_public
-          );
+          )
         }
       } else {
-        let url = findUrl(body.message.text);
-        console.log(url);
-        let message = body.message.text.replace(/<.*>/, "");
-        console.log(message);
-        logShip(body.message.ts, body.message.user, message, null, url);
+        let url = findUrl(body.message.text)
+        console.log(url)
+        let message = body.message.text.replace(/<.*>/, '')
+        console.log(message)
+        logShip(body.message.ts, body.message.user, message, null, url)
       }
     }
   }
-});
+})
 
 const logShip = async (ts, userId, message, imageUrl, projectUrl) => {
   let userInfo = await app.client.users.info({
     token: process.env.BOT_TOKEN,
     user: userId,
-  });
-  let username = `@${userInfo.user.name}`;
-  let avatar = userInfo.user.profile.image_192;
+  })
+  let username = `@${userInfo.user.name}`
+  let avatar = userInfo.user.profile.image_192
 
   let profile = await app.client.users.profile.get({
     token: process.env.BOT_TOKEN,
     user: userId,
-  });
+  })
 
-  let website;
+  let website
   try {
-    website = profile.profile.fields["Xf5LNGS86L"].value;
+    website = profile.profile.fields['Xf5LNGS86L'].value
   } catch {}
 
-  let d = new Date(ts * 1000);
+  let d = new Date(ts * 1000)
 
   shipsTable.create({
     Timestamp: d.toISOString(),
     Message: message,
-    "User ID": userId,
-    "User Name": username,
-    "User Avatar": avatar,
-    "User Website": website,
-    "Image URL": imageUrl,
-    "Project URL": projectUrl,
+    'User ID': userId,
+    'User Name': username,
+    'User Avatar': avatar,
+    'User Website': website,
+    'Image URL': imageUrl,
+    'Project URL': projectUrl,
     Public: true,
-  });
-};
+  })
+}
 
 const hasUrl = (message) =>
   new RegExp(
-    "([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?(/.*)?"
-  ).test(message);
+    '([a-zA-Z0-9]+://)?([a-zA-Z0-9_]+:[a-zA-Z0-9_]+@)?([a-zA-Z0-9.-]+\\.[A-Za-z]{2,4})(:[0-9]+)?(/.*)?'
+  ).test(message)
 
 const findUrl = (message) => {
-  let url = message.match(/<.*>/)[0];
-  return url.slice(1, url.indexOf("|"));
-};
+  let url = message.match(/<.*>/)[0]
+  return url.slice(1, url.indexOf('|'))
+}
 
-(async () => {
-  await app.start(process.env.PORT || 3000);
-  console.log("⚡️ Bolt app is running!");
-})();
+;(async () => {
+  await app.start(process.env.PORT || 3000)
+  console.log('⚡️ Bolt app is running!')
+})()

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'none',
+  arrowParens: 'avoid',
+  printWidth: 80,
+  semi: false
+}


### PR DESCRIPTION
Uses slack's (semi-undocumented but production-ready) `broadcast_delete` operator. Currently the bot does not delete threaded messages sent to the channel - this should delete the message from the public channel but keep it in the thread.